### PR TITLE
Add hashing traits and interfaces

### DIFF
--- a/hash.php
+++ b/hash.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * @author Chris Zuber
+ * @package shgysk8zer0\PHPCrypt
+ * @version 1.0.0
+ * @copyright 2017, Chris Zuber
+ * @license http://opensource.org/licenses/GPL-3.0 GNU General Public License, version 3 (GPL-3.0)
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+namespace shgysk8zer0\PHPCrypt;
+/**
+ * @see https://secure.php.net/manual/en/function.hash-file.php
+ * @see https://secure.php.net/manual/en/function.hash.php
+ */
+final class Hash implements Interfaces\Hash, Interfaces\HashFile
+{
+	use Traits\Hash;
+	use Traits\HashFile;
+}

--- a/index.php
+++ b/index.php
@@ -7,6 +7,14 @@ const PRIVATE_KEY = 'private.pem';
 const MESSAGE     = 'Hello world!';
 const ERROR_LOG   = 'errors.log';
 
+if (! in_array(PHP_SAPI, ['cli', 'cli-server'])) {
+	http_response_code(503);
+	exit();
+} elseif (version_compare(\PHP_VERSION, '7.0.0', '<')) {
+	echo 'PHP version 7 or greater is required.' . PHP_EOL;
+	exit(1);
+}
+
 set_include_path(dirname(__DIR__, 2) . PATH_SEPARATOR . __DIR__);
 spl_autoload_register('spl_autoload');
 
@@ -39,7 +47,12 @@ function error_handler(
 function exception_handler(\Throwable $exc)
 {
 	error_log($exc . PHP_EOL, 3, ERROR_LOG);
-	echo $exc . PHP_EOL;
+	echo json_encode([
+		'message' => $exc->getMessage(),
+		'file'    => $exc->getFile(),
+		'line'    => $exc->getLine(),
+		'trace'   => $exc->getTrace(),
+	], JSON_PRETTY_PRINT) . PHP_EOL;
 	exit(1);
 }
 
@@ -52,23 +65,37 @@ $pair->private->exportToFile(PRIVATE_KEY, PASSWORD);
 
 $keys = new KeyPair(PUBLIC_KEY, PRIVATE_KEY, PASSWORD);
 
-$encrypted = $keys->encrypt(MESSAGE);
-$decrypted = $keys->decrypt($encrypted);
-$sig       = $keys->sign($encrypted);
-$valid     = $keys->verify($encrypted, $sig);
+$encrypted  = $keys->encrypt(MESSAGE);
+$decrypted  = $keys->decrypt($encrypted);
+$sig        = $keys->sign($encrypted);
+$valid      = $keys->verify($encrypted, $sig);
+$hash       = Hash::sha384(MESSAGE);
+$matches    = Hash::match(MESSAGE, $hash);
+$file_hash  = Hash::sha512File(__FILE__);
+$file_match = Hash::matchFile(__FILE__, $file_hash);
 
-print_r([
-	'keys'      => "$keys",
-	'message'   => MESSAGE,
-	'encrypted' => $encrypted,
-	'decrypted' => $decrypted,
-	'match'     => MESSAGE === $decrypted,
-	'signature' => $sig,
-	'valid'     => $valid,
-]);
+
+@header('Content-Type: application/json');
+echo json_encode([
+	'keys'       => "$keys",
+	'message'    => MESSAGE,
+	'encrypted'  => $encrypted,
+	'decrypted'  => $decrypted,
+	'match'      => MESSAGE === $decrypted,
+	'signature'  => $sig,
+	'valid'      => $valid,
+	'hash'       => $hash,
+	'hash match' => $matches,
+	'file hash'  => $file_hash,
+	'file match' => $file_match,
+], JSON_PRETTY_PRINT);
 
 if (!$decrypted === MESSAGE) {
 	trigger_error('Decrypted message does not match original.');
 } elseif (!$valid) {
 	trigger_error('Signature not valid.');
+} elseif (!$matches) {
+	trigger_error('Hash does not match');
+} elseif (!$file_match) {
+	trigger_error(sprintf('Hash for %s did not match', __FILE__));
 }

--- a/interfaces/hash.php
+++ b/interfaces/hash.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * @author Chris Zuber
+ * @package shgysk8zer0\PHPCrypt
+ * @subpackage Interfaces
+ * @version 1.0.0
+ * @copyright 2017, Chris Zuber
+ * @license http://opensource.org/licenses/GPL-3.0 GNU General Public License, version 3 (GPL-3.0)
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+namespace shgysk8zer0\PHPCrypt\Interfaces;
+/**
+ * @see https://secure.php.net/manual/en/function.hash.php
+ */
+interface Hash
+{
+	/**
+	 * Generates a SHA-1 digest
+	 * @param  String $str Message to be hashed
+	 * @return String      The calculated message digest as lowercase hexits
+	 */
+	public static function sha1(String $str): String;
+
+	/**
+	 * Generates a SHA-256 digest
+	 * @param  String $str Message to be hashed
+	 * @return String      The calculated message digest as lowercase hexits
+	 */
+	public static function sha256(String $str): String;
+
+	/**
+	 * Generates a SHA-384 digest
+	 * @param  String $str Message to be hashed
+	 * @return String      The calculated message digest as lowercase hexits
+	 */
+	public static function sha384(String $str): String;
+	/**
+	 * Generates a SHA-512 digets
+	 * @param  String $str Message to be hashed
+	 * @return String      The calculated message digest as lowercase hexits
+	 */
+	public static function sha512(String $str): String;
+
+	/**
+	 * Timing attack safe string comparison
+	 * @param  String $str  The message
+	 * @param  String $hash The hash to check against
+	 * @return Bool         If the hash matches the message
+	 * @see https://php.net/manual/en/function.hash-equals.php
+	 */
+	public static function match(String $str, String $hash): Bool;
+}

--- a/interfaces/hashfile.php
+++ b/interfaces/hashfile.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * @author Chris Zuber
+ * @package shgysk8zer0\PHPCrypt
+ * @subpackage Interfaces
+ * @version 1.0.0
+ * @copyright 2017, Chris Zuber
+ * @license http://opensource.org/licenses/GPL-3.0 GNU General Public License, version 3 (GPL-3.0)
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+namespace shgysk8zer0\PHPCrypt\Interfaces;
+/**
+ * @see https://secure.php.net/manual/en/function.hash-file.php
+ */
+interface HashFile
+{
+	/**
+	 * Generates a SHA-1 digest from a file
+	 * @param  String $fname File to be hashed
+	 * @return String        The calculated file digest as lowercase hexits
+	 */
+	public static function sha1File(String $fname): String;
+
+	/**
+	 * Generates a SHA-256 digest from a file
+	 * @param  String $fname File to be hashed
+	 * @return String        The calculated file digest as lowercase hexits
+	 */
+	public static function sha256File(String $fname): String;
+
+	/**
+	 * Generates a SHA-384 digest from a file
+	 * @param  String $fname File to be hashed
+	 * @return String        The calculated file digest as lowercase hexits
+	 */
+	public static function sha384File(String $fname): String;
+
+	/**
+	 * Generates a SHA-512 digets from a file
+	 * @param  String $fname File to be hashed
+	 * @return String        The calculated file digest as lowercase hexits
+	 */
+	public static function sha512File(String $fname): String;
+
+	/**
+	 * Timing attack safe file comparison
+	 * @param  String $fname  The file
+	 * @param  String $hash   The hash to check against
+	 * @return Bool           If the hash matches the file
+	 * @see https://php.net/manual/en/function.hash-equals.php
+	 */
+	public static function matchFile(String $fname, String $hash): Bool;
+}

--- a/traits/hash.php
+++ b/traits/hash.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * @author Chris Zuber
+ * @package shgysk8zer0\PHPCrypt
+ * @subpackage Traits
+ * @version 1.0.0
+ * @copyright 2017, Chris Zuber
+ * @license http://opensource.org/licenses/GPL-3.0 GNU General Public License, version 3 (GPL-3.0)
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+namespace shgysk8zer0\PHPCrypt\Traits;
+/**
+ * @see https://secure.php.net/manual/en/function.hash.php
+ */
+trait Hash
+{
+	/**
+	 * Generates a SHA-1 digest
+	 * @param  String $str Message to be hashed
+	 * @return String      The calculated message digest as lowercase hexits
+	 */
+	final public static function sha1(String $str): String
+	{
+		return hash('sha1', $str);
+	}
+
+	/**
+	 * Generates a SHA-256 digest
+	 * @param  String $str Message to be hashed
+	 * @return String      The calculated message digest as lowercase hexits
+	 */
+	final public static function sha256(String $str): String
+	{
+		return hash('sha256', $str);
+	}
+
+	/**
+	 * Generates a SHA-384 digest
+	 * @param  String $str Message to be hashed
+	 * @return String      The calculated message digest as lowercase hexits
+	 */
+	final public static function sha384(String $str): String
+	{
+		return hash('sha384', $str);
+	}
+
+	/**
+	 * Generates a SHA-512 digets
+	 * @param  String $str Message to be hashed
+	 * @return String      The calculated message digest as lowercase hexits
+	 */
+	final public static function sha512(String $str): String
+	{
+		return hash('sha512', $str);
+	}
+
+	/**
+	 * Timing attack safe string comparison
+	 * @param  String $str  The message
+	 * @param  String $hash The hash to check against
+	 * @return Bool         If the hash matches the message
+	 * @see https://php.net/manual/en/function.hash-equals.php
+	 */
+	final public static function match(String $str, String $hash): Bool
+	{
+		return hash_equals($str, $hash);
+	}
+}

--- a/traits/hash.php
+++ b/traits/hash.php
@@ -74,6 +74,27 @@ trait Hash
 	 */
 	final public static function match(String $str, String $hash): Bool
 	{
+		switch(strlen($hash)) {
+			case 40:
+				$str = static::sha1($str);
+				break;
+
+			case 64:
+				$str = static::sha256($str);
+				break;
+
+			case 96:
+				$str = static::sha384($str);
+				break;
+
+			case 128:
+				$str = static::sha512($str);
+				break;
+
+			default:
+				trigger_error('Could not match with any supported hashing algorithm.');
+				$str = '';
+		}
 		return hash_equals($str, $hash);
 	}
 }

--- a/traits/hashfile.php
+++ b/traits/hashfile.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * @author Chris Zuber
+ * @package shgysk8zer0\PHPCrypt
+ * @subpackage Traits
+ * @version 1.0.0
+ * @copyright 2017, Chris Zuber
+ * @license http://opensource.org/licenses/GPL-3.0 GNU General Public License, version 3 (GPL-3.0)
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+namespace shgysk8zer0\PHPCrypt\Traits;
+/**
+ * @see https://secure.php.net/manual/en/function.hash-file.php
+ */
+trait HashFile
+{
+	/**
+	 * Generates a SHA-1 digest from a file
+	 * @param  String $fname File to be hashed
+	 * @return String        The calculated file digest as lowercase hexits
+	 */
+	final public static function sha1File(String $fname): String
+	{
+		return hash_file('sha1', $fname);
+	}
+
+	/**
+	 * Generates a SHA-256 digest from a file
+	 * @param  String $fname File to be hashed
+	 * @return String        The calculated file digest as lowercase hexits
+	 */
+	final public static function sha256File(String $fname): String
+	{
+		return hash_file('sha256', $fname);
+	}
+
+	/**
+	 * Generates a SHA-384 digest from a file
+	 * @param  String $fname File to be hashed
+	 * @return String        The calculated file digest as lowercase hexits
+	 */
+	final public static function sha384File(String $fname): String
+	{
+		return hash_file('sha384', $fname);
+	}
+
+	/**
+	 * Generates a SHA-512 digets from a file
+	 * @param  String $fname File to be hashed
+	 * @return String        The calculated file digest as lowercase hexits
+	 */
+	final public static function sha512File(String $fname): String
+	{
+		return hash_file('sha512', $fname);
+	}
+
+	/**
+	 * Timing attack safe file comparison
+	 * @param  String $fname  The file
+	 * @param  String $hash   The hash to check against
+	 * @return Bool           If the hash matches the file
+	 * @see https://php.net/manual/en/function.hash-equals.php
+	 */
+	final public static function matchFile(String $fname, String $hash): Bool
+	{
+		return hash_equals(file_get_contents($fname), $hash);
+	}
+}

--- a/traits/hashfile.php
+++ b/traits/hashfile.php
@@ -74,6 +74,27 @@ trait HashFile
 	 */
 	final public static function matchFile(String $fname, String $hash): Bool
 	{
-		return hash_equals(file_get_contents($fname), $hash);
+		switch(strlen($hash)) {
+			case 40:
+				$str = static::sha1File($fname);
+				break;
+
+			case 64:
+				$str = static::sha256File($fname);
+				break;
+
+			case 96:
+				$str = static::sha384File($fname);
+				break;
+
+			case 128:
+				$str = static::sha512File($fname);
+				break;
+
+			default:
+				trigger_error('Could not match with any supported hashing algorithm.');
+				$str = '';
+		}
+		return hash_equals($str, $hash);
 	}
 }


### PR DESCRIPTION
## Add hashing. Fixes #6 

All use static methods for SHA-1, SHA-256, SHA-384, & SHA-512 hashing algorithms.

### List of significant changes made
-   `Hash` trait
-   `HashFile` trait 
-   `Hash` interface
-   `HashFile` interface
-   `Hash` class implementing `Hash` & `HashFile` interfaces, using `Hash` & `HashFile` traits
-   Add hash testing 

